### PR TITLE
Add custom theme with individual gauge colors (CPU green, GPU magenta, Memory blue, ANE red)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -564,7 +564,7 @@ func updateCPUUI(cpuMetrics CPUMetrics) {
 
 	// Update gauge colors with dynamic saturation if 1977 theme is active
 	if currentConfig.Theme == "1977" {
-		updateCustomGaugeColors()
+		update1977GaugeColors()
 	}
 }
 
@@ -607,7 +607,7 @@ func updateGPUUI(gpuMetrics GPUMetrics) {
 
 	// Update gauge colors with dynamic saturation if 1977 theme is active
 	if currentConfig.Theme == "1977" {
-		updateCustomGaugeColors()
+		update1977GaugeColors()
 	}
 }
 

--- a/internal/app/theme.go
+++ b/internal/app/theme.go
@@ -83,7 +83,7 @@ func getANEColor(percent int) ui.Color {
 	return ui.ColorRed
 }
 
-func updateCustomGaugeColors() {
+func update1977GaugeColors() {
 	if cpuGauge != nil {
 		cpuColor := getCPUColor(cpuGauge.Percent)
 		cpuGauge.BarColor = cpuColor
@@ -233,7 +233,7 @@ func applyTheme(colorName string, lightMode bool) {
 	ui.Theme.BarChart.Bars = []ui.Color{color}
 
 	if is1977 {
-		updateCustomGaugeColors()
+		update1977GaugeColors()
 	} else {
 		applyThemeToGauges(color)
 	}


### PR DESCRIPTION
## Summary
This PR adds a custom theme option to mactop that displays different colors for each system resource gauge, making it easier to distinguish between CPU, GPU, Memory, and ANE usage at a glance.

## Changes
- Added 'custom' theme option to color cycling (press 'c' to cycle through themes)
- Custom theme displays individual colors for each gauge:
  - **CPU**: Green
  - **GPU**: Magenta (purple-like)
  - **Memory**: Blue
  - **ANE**: Red
- Uses standard terminal colors for better compatibility across different terminals
- Added color update call in `updateGPUUI()` to ensure GPU colors update properly

## Testing
- Tested on macOS with Apple Silicon
- Colors display correctly in terminal
- Theme can be activated by pressing 'c' key or using `--color custom` flag

## Benefits
- Improved visual distinction between different system resources
- Better user experience when monitoring multiple metrics simultaneously
- Maintains backward compatibility with existing themes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new '1977' theme that assigns fixed colors to CPU/GPU/Memory/ANE gauges and refreshes them during CPU/GPU updates.
> 
> - **Theme**:
>   - Add `"1977"` to `colorNames` and support it in `applyTheme`, special-casing per-gauge colors while keeping global theme color defaults.
>   - Implement `update1977GaugeColors()` to set per-gauge standard colors (`CPU` green, `GPU` magenta, `Memory` blue, `ANE` red).
> - **UI Updates**:
>   - Invoke `update1977GaugeColors()` in `updateCPUUI()` and `updateGPUUI()` when `currentConfig.Theme == "1977"` for dynamic color refresh.
> - **Helpers**:
>   - Add RGB and saturation helpers (`rgbColor`, `adjustColorSaturation`) and per-gauge color getters (`getCPUColor`, `getGPUColor`, `getMemoryColor`, `getANEColor`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 443beddaa10cddd5517ca89921e86d4d3179f043. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->