### PR TITLE
Fix process selection color for root user

### DIFF
--- a/internal/app/processes.go
+++ b/internal/app/processes.go
@@ -403,7 +403,7 @@ func buildProcessRows(processes []ProcessMetrics, maxWidths map[string]int) []st
 			truncateWithEllipsis(cmdName, maxWidths["CMD"]),
 		)
 
-		if p.User != currentUser {
+		if currentUser != "root" && p.User != currentUser {
 			color := GetProcessTextColor(false)
 			items[i] = fmt.Sprintf("[%s](fg:%s)", line, color)
 		} else {


### PR DESCRIPTION
### Background
When the application is executed as root, all processes can already be
terminated. However, the UI only marked root-owned processes as
selectable, which was misleading.

### Changes
- Updated the color logic so that all processes are shown as selectable
  when running as root.
- No changes to kill logic or permission checks.

### Rationale
- Root users already have permission to terminate any process. The previous
color scheme suggested otherwise and could cause confusion.

### Impact
- Improves UI clarity and correctness for root users.
- No functional changes.
- No behavior change for non-root users.

### Testing
- Verified that all processes are visually marked as selectable when
  running as root.
- Confirmed no change in kill behavior.
