### PR TITLE
Add F9 hotkey to kill process during search mode

### DIFF
--- a/internal/app/processes.go
+++ b/internal/app/processes.go
@@ -535,6 +535,8 @@ func handleSearchInput(e ui.Event) {
 	case "<Enter>":
 		searchMode = false
 		updateProcessList()
+	case "<F9>":
+		attemptKillProcess()
 	case "<Backspace>":
 		if len(searchText) > 0 {
 			runes := []rune(searchText)


### PR DESCRIPTION
## Summary
Added support for the F9 hotkey to terminate a process while in search mode, improving the user experience by allowing quick process termination without exiting the search interface.

## Changes
- Added F9 key binding in the `handleSearchInput` function to call `attemptKillProcess()`
- Users can now kill a process directly from search mode without needing to exit search first

## Implementation Details
The F9 hotkey is handled as a new case in the search input event handler, maintaining consistency with the existing keybinding pattern. When pressed, it invokes the existing `attemptKillProcess()` function, which handles the actual process termination logic.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Allows killing the selected process directly from the search interface.
> 
> - Adds `"<F9>"` case in `handleSearchInput` to call `attemptKillProcess()`
> - Maintains existing search behaviors (escape/enter/backspace/space) unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80a41a09354a8f22e95e0d03466dd83d79d33412. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->