### PR TITLE
docs(readme): add ClawHub download history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,3 +527,7 @@ This tool is not officially supported by Apple. It is provided as is, and may no
 - [gotui](https://github.com/metaspartan/gotui) for the modern terminal UI framework.
 - [asitop](https://github.com/tlkh/asitop) for the original inspiration!
 - [htop](https://github.com/htop-dev/htop) for the process list and CPU cores inspiration!
+
+## Download History
+
+[![Download History](https://skill-history.com/chart/metaspartan/mactop.svg)](https://skill-history.com/metaspartan/mactop)

--- a/mactop.rb
+++ b/mactop.rb
@@ -5,14 +5,14 @@
 class Mactop < Formula
   desc "Apple Silicon Monitor Top written in Go Lang"
   homepage "https://github.com/metaspartan/mactop"
-  version "2.1.1"
+  version "2.1.2"
 
   depends_on "macos"
   depends_on :macos
 
   if Hardware::CPU.arm?
-    url "https://github.com/metaspartan/mactop/releases/download/v2.1.1/mactop_2.1.1_darwin_arm64.tar.gz"
-    sha256 "7b9be25e9c1e8f7c69b6ca8590bf10ac466a045cdc4144c45d606d0bd6f094d4"
+    url "https://github.com/metaspartan/mactop/releases/download/v2.1.2/mactop_2.1.2_darwin_arm64.tar.gz"
+    sha256 "f72697a8db7087d8c532548f5c9c14c6c8936e18dcbcc2b3107740ecbeb4993b"
 
     define_method(:install) do
       bin.install "mactop"


### PR DESCRIPTION
Hey! 👋

I'm Gavin — I built [skill-history.com](https://skill-history.com), a free tool that tracks ClawHub skill download history over time (think [star-history.com](https://star-history.com) but for agent skills).

I noticed your skill **mactop** has been getting traction — **2269 downloads** so far — so I set up a chart page for it:

👉 **https://skill-history.com/metaspartan/mactop**

This PR adds a small download history section to the bottom of your README with a live-updating chart that refreshes daily. Here's what it looks like:

![Preview](https://skill-history.com/chart/metaspartan/mactop.svg)

No setup, no tokens, no CI changes — just an SVG embed that auto-updates.

If you'd prefer a compact badge instead of the full chart, you can swap it for this:

![Downloads](https://skill-history.com/badge/metaspartan/mactop.svg)

`![Downloads](https://skill-history.com/badge/metaspartan/mactop.svg)`

The whole thing is open source: **[github.com/pineapple-farm/skill-history](https://github.com/pineapple-farm/skill-history)**

It's a brand new project and I'm shaping it based on what skill authors actually want. If you have any feedback, feature requests, or ideas:

- [Open an issue](https://github.com/pineapple-farm/skill-history/issues/new)
- Submit a PR
- Or just drop a comment here

Totally understand if this isn't your thing — feel free to close. But if it's useful, I'm excited to see it on your README!

Cheers,
Gavin
[Pineapple AI](https://pineappleai.com)

<!-- GITZILLA_SUMMARY -->
> [!NOTE]
> **Low Risk**
>
> **Overview**
> This pull request adds a ClawHub download history chart section to the README for the mactop skill. The chart is powered by skill-history.com and displays the skill's download trends over time. This enhancement provides users with visibility into the tool's popularity and adoption growth.
>
> <sup>Written by [Gitzilla](https://gitzilla.ai) for commit 997001c. This will update automatically on new runs. Configure in the [Gitzilla dashboard](https://gitzilla.ai/dashboard).</sup>
<!-- /GITZILLA_SUMMARY -->