### PR TITLE
Add Traditional Chinese (zh-Hant) locale

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@
 - Support for all Apple Silicon models
 - **Auto-detect Light/Dark Mode**: Automatically adjusts UI colors based on your terminal's background color or system theme.
 - **Configurable Units**: Customize units for network, disk, and temperature display (`--unit-network`, `--unit-disk`, `--unit-temp`)
-- **Multi-Language Support (i18n)**: 19 languages with automatic system language detection — English, Arabic, Chinese, Dutch, French, German, Hebrew, Hindi, Indonesian, Italian, Japanese, Korean, Polish, Portuguese, Russian, Spanish, Thai, Turkish, Vietnamese (`--lang` to override)
+- **Multi-Language Support (i18n)**: 20 languages with automatic system language detection — English, Arabic, Chinese (Simplified & Traditional), Dutch, French, German, Hebrew, Hindi, Indonesian, Italian, Japanese, Korean, Polish, Portuguese, Russian, Spanish, Thai, Turkish, Vietnamese (`--lang` to override)
 
 ## Install via Homebrew
 

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -84,50 +84,50 @@ func TData(id string, templateData map[string]any) string {
 
 // detectSystemLanguage attempts to read the macOS system language.
 func detectSystemLanguage() string {
-	// First try macOS defaults command
-	cmd := exec.Command("defaults", "read", "-g", "AppleLanguages")
-	out, err := cmd.Output()
-	if err == nil {
-		// Output looks like:
-		// (
-		//     "en-US",
-		//     "es-US"
-		// )
-		lines := strings.SplitSeq(string(out), "\n")
-		for line := range lines {
+	if out, err := exec.Command("defaults", "read", "-g", "AppleLanguages").Output(); err == nil {
+		for line := range strings.SplitSeq(string(out), "\n") {
 			line = strings.TrimSpace(line)
-			if strings.HasPrefix(line, "\"") && strings.HasSuffix(line, "\",") {
-				lang := strings.Trim(line, "\",")
-				// Convert en-US to en, es-US to es
-				parts := strings.Split(lang, "-")
-				if len(parts) > 0 {
-					return parts[0]
-				}
-				return lang
-			} else if strings.HasPrefix(line, "\"") && strings.HasSuffix(line, "\"") {
-				lang := strings.Trim(line, "\"")
-				parts := strings.Split(lang, "-")
-				if len(parts) > 0 {
-					return parts[0]
-				}
-				return lang
+			if !strings.HasPrefix(line, "\"") {
+				continue
+			}
+			if tag := normalizeLanguageTag(strings.Trim(line, "\",")); tag != "" {
+				return tag
 			}
 		}
 	}
 
-	// Fallback to standard environment variables
-	if lang := os.Getenv("LC_ALL"); lang != "" {
-		parts := strings.Split(lang, "_")
-		if len(parts) > 0 {
-			return parts[0]
-		}
-	}
-	if lang := os.Getenv("LANG"); lang != "" {
-		parts := strings.Split(lang, "_")
-		if len(parts) > 0 {
-			return parts[0]
+	for _, env := range []string{"LC_ALL", "LANG"} {
+		if tag := normalizeLanguageTag(os.Getenv(env)); tag != "" {
+			return tag
 		}
 	}
 
 	return ""
+}
+
+// normalizeLanguageTag maps a raw BCP-47 or POSIX locale to a shipped tag.
+// zh-TW, zh-HK, zh-MO, and zh-Hant* return "zh-Hant"; other zh variants return
+// "zh"; otherwise the primary subtag is kept.
+func normalizeLanguageTag(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	normalized := strings.ReplaceAll(raw, "_", "-")
+	if dot := strings.Index(normalized, "."); dot != -1 {
+		normalized = normalized[:dot]
+	}
+	parts := strings.Split(strings.ToLower(normalized), "-")
+	if len(parts) == 0 || parts[0] == "" {
+		return ""
+	}
+	if parts[0] == "zh" {
+		for _, part := range parts[1:] {
+			switch part {
+			case "hant", "tw", "hk", "mo":
+				return "zh-Hant"
+			}
+		}
+		return "zh"
+	}
+	return parts[0]
 }

--- a/internal/i18n/i18n_test.go
+++ b/internal/i18n/i18n_test.go
@@ -14,6 +14,47 @@ var (
 	fmtPlaceholderRE = regexp.MustCompile(`%(\[[0-9]+\])?[-+# 0-9.*]*[bcdeEfFgGosxXvTtU%]`)
 )
 
+func TestNormalizeLanguageTag(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"english primary", "en", "en"},
+		{"english region", "en-US", "en"},
+		{"english POSIX", "en_US.UTF-8", "en"},
+		{"japanese region", "ja-JP", "ja"},
+		{"japanese POSIX", "ja_JP.UTF-8", "ja"},
+		{"zh primary", "zh", "zh"},
+		{"zh-CN", "zh-CN", "zh"},
+		{"zh-Hans", "zh-Hans", "zh"},
+		{"zh-Hans-CN", "zh-Hans-CN", "zh"},
+		{"zh-SG", "zh-SG", "zh"},
+		{"zh POSIX CN", "zh_CN.UTF-8", "zh"},
+		{"zh-TW legacy", "zh-TW", "zh-Hant"},
+		{"zh-HK legacy", "zh-HK", "zh-Hant"},
+		{"zh-MO legacy", "zh-MO", "zh-Hant"},
+		{"zh-Hant", "zh-Hant", "zh-Hant"},
+		{"zh-Hant-TW", "zh-Hant-TW", "zh-Hant"},
+		{"zh-Hant-HK", "zh-Hant-HK", "zh-Hant"},
+		{"zh POSIX TW", "zh_TW.UTF-8", "zh-Hant"},
+		{"zh POSIX HK", "zh_HK.UTF-8", "zh-Hant"},
+		{"mixed case Hant", "ZH-hAnT-tw", "zh-Hant"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := normalizeLanguageTag(tc.in); got != tc.want {
+				t.Fatalf("normalizeLanguageTag(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestLocalesMatchEnglishCatalog(t *testing.T) {
 	files, err := localeFS.ReadDir("locales")
 	if err != nil {

--- a/internal/i18n/locales/active.zh-Hant.toml
+++ b/internal/i18n/locales/active.zh-Hant.toml
@@ -1,0 +1,357 @@
+Overlay_FPS = "FPS"
+Overlay_FrameInfo = "影格間隔"
+Overlay_CPU = "CPU"
+Overlay_GPU = "GPU"
+Overlay_ANE = "ANE"
+Overlay_Memory = "記憶體"
+Overlay_Swap = "置換空間"
+Overlay_Power = "功耗"
+Overlay_Bandwidth = "DRAM 頻寬"
+Overlay_GPUFreq = "GPU 頻率"
+Overlay_Temps = "溫度"
+Overlay_Thermal = "散熱狀態"
+Overlay_Fans = "風扇"
+Overlay_Network = "網路"
+
+TUI_InfoLayoutColorExit = " 資訊: i | 版面: l | 顏色: c | 背景: b | 離開: q "
+TUI_LayoutInfo = " %d/%d 版面 (%s) "
+TUI_LayoutInfoShort = " %d/%d "
+TUI_ModelInfo = "型號: %s"
+TUI_CoresInfo = "%d 核心 (%dP, %dE, %dS) | GPU: %d 核心 | %s"
+TUI_TotalPower = "總功耗: %.1fW"
+TUI_AppTotalPower = "總計: %.1fW | CPU: %.1fW (ANE: %.1fW) GPU: %.1fW"
+TUI_AppleSilicon = "Apple Silicon"
+TUI_HelpMenu = "mactop 說明選單"
+TUI_Loading = "載入中..."
+TUI_LoadingTB = "載入 Thunderbolt 資訊..."
+TUI_Fans = " ⊚ 風扇 "
+TUI_Temperatures = " 🌡 溫度 "
+TUI_ProcessList = "行程列表"
+TUI_UnknownModel = "未知型號"
+TUI_ECPUUsage = "E-CPU 使用率"
+TUI_PCPUUsage = "P-CPU 使用率"
+TUI_GPUUsage = "GPU 使用率"
+TUI_MemoryUsage = "記憶體使用率"
+TUI_ANEUsage = "ANE 使用率"
+TUI_PowerUsage = "功耗"
+TUI_NetworkDisk = "網路與磁碟"
+TUI_ThunderboltRDMA = "Thunderbolt / RDMA"
+TUI_MactopTitle = " mactop "
+TUI_GPUUsageHistory = "GPU 使用歷史"
+TUI_TBNet = "TB 網路 ↓0/s ↑0/s"
+TUI_PowerHistory = "功耗歷史"
+TUI_MemorySwapHistory = "記憶體/置換歷史"
+TUI_CPUUsageHistory = "CPU 使用歷史"
+TUI_ConfirmKill = " 確認結束 "
+TUI_ConfirmKillBody = "確認結束行程"
+TUI_ConfirmYes = "是"
+TUI_ConfirmNo = "否"
+
+Info_OS = "作業系統"
+Info_Host = "主機"
+Info_Kernel = "核心"
+Info_Uptime = "運行時間"
+Info_Shell = "Shell"
+Info_CPU = "CPU"
+Info_GPU = "GPU"
+Info_TFLOPs = "TFLOPs"
+Info_Memory = "記憶體"
+Info_Swap = "置換空間"
+Info_CPUUsage = "CPU 使用率"
+Info_GPUUsage = "GPU 使用率"
+Info_ANEUsage = "ANE 使用率"
+Info_Power = "功耗"
+Info_Thermals = "溫度"
+Info_Network = "網路"
+Info_Disk = "磁碟"
+Info_DRAMBW = "DRAM 頻寬"
+Info_TBNet = "TB 網路"
+Info_RDMA = "RDMA"
+Info_Ethernet = "乙太網路"
+Info_WiFi = "Wi-Fi"
+
+Metrics_MemoryUsed = "%.1fGB / %.1fGB %.1f%%"
+Metrics_SwapUsed = "置換: %.1fGB / %.1fGB %.1f%%"
+Metrics_DiskIO = "[讀] %.1f%s [寫] %.1f%s"
+Metrics_NetIO = "[入] %s [出] %s"
+Metrics_TFLOPs = "FP32 TFLOPs: %.1f"
+Metrics_Freq = "頻率: %d MHz"
+Metrics_RPM = "%d RPM"
+Metrics_ThermalNominal = "正常"
+Metrics_ThermalFair = "尚可"
+Metrics_ThermalSerious = "嚴重"
+Metrics_ThermalCritical = "危險"
+Metrics_ThermalUnknown = "未知"
+Metrics_RDMAActive = "運作中"
+Metrics_RDMAInactive = "未運作"
+Metrics_CPUGaugeCompact = "CPU %.0f%% %s"
+Metrics_CPUGauge = "%d 核心 %s %.2f%%%s (%s)"
+Metrics_ANEGaugeCompact = "ANE %.1fW"
+Metrics_ANEGauge = "ANE 使用率: %.2f%% @ %.2f W"
+Metrics_PowerChartTitleCompact = "功耗"
+Metrics_PowerChartTextCompact = "C:%.1fW G:%.1fW\nA:%.1fW D:%.1fW\n總:%.1fW %s"
+Metrics_PowerChartText = "CPU: %.2f W | GPU: %.2f W\nANE: %.2f W | DRAM: %.2f W\n系統: %.2f W\n總計: %.2f W\n散熱: %s\n運行時間: %s"
+Metrics_NetworkDiskTitle = "網路與磁碟"
+Metrics_MemGaugeCompact = "記憶體 %.0f/%.0fG 頻寬 %.1f GB/s"
+Metrics_MemGauge = "記憶體: %.2f GB / %.2f GB (置換: %.2f/%.2f GB) 頻寬: %.1f GB/s"
+
+Process_PID = "PID"
+Process_USER = "使用者"
+Process_VIRT = "虛擬"
+Process_RES = "實體"
+Process_CPU = "CPU"
+Process_GPU = "GPU"
+Process_MEM = "記憶體"
+Process_TIME = "時間"
+Process_CMD = "命令"
+
+TUI_ProcessListFull = "行程列表 (↑/↓ 捲動, / 搜尋, f 凍結, F9 結束)"
+TUI_ProcessListFrozen = " 行程列表 [已凍結] (按 f 恢復) "
+TUI_ProcessListSearch = " 搜尋: %s_ (Esc 清除) "
+TUI_ProcessListKill = " 行程列表 - 待確認結束 (PID %d) "
+TUI_ProcessListPID = " 行程列表 [PID %d] (↑/↓ 捲動, / 搜尋, f 凍結, F9 結束) "
+TUI_Cores = "%d 核心"
+TUI_ECores = "%d E-Cores"
+TUI_PCores = "%d P-Cores"
+TUI_SCores = "%d S-Cores"
+TUI_GPUCores = "%s GPU 核心"
+Metrics_NetLink = "網路 (%s): ↑ %s/s ↓ %s/s"
+Metrics_Net = "網路: ↑ %s/s ↓ %s/s"
+Metrics_IO = "I/O: 讀 %s/s 寫 %s/s"
+Metrics_DiskFree = "%s: %s/%s (%s 可用)"
+Metrics_GPUGaugeTemp = "GPU 使用率: %d%% @ %d MHz (%s)"
+Metrics_GPUGaugeFreq = "GPU 使用率: %d%% @ %d MHz"
+Metrics_GPUSparkline = "GPU 歷史: %d%% (平均: %.1f%%)"
+Metrics_GPUHistoryChart = "GPU 使用歷史 (平均: %.1f%%)"
+Metrics_GPUGaugeCompactTemp = "GPU %d%% %s"
+Metrics_GPUGaugeCompactFreq = "GPU %d%% %dMHz"
+Metrics_GPUSparklineCompact = "GPU %d%% (%.0f%%)"
+
+Help_FullText = """
+mactop 是由 Carsen Klock 以 Go 語言撰寫的 Apple Silicon 開源監控工具！
+
+儲存庫: github.com/metaspartan/mactop
+
+----目前設定----
+Prometheus 指標: %s
+版本: %s
+版面: %s
+前景色: %s
+背景色: %s
+更新間隔: %dms
+
+----操作控制----
+- r: 手動重新整理 UI 資料
+- c: 切換 UI 顏色主題
+- b: 切換 UI 背景色
+- p: 開啟/關閉派對模式 (顏色循環)
+- l: 在 18 種可用版面中切換
+- i: 切換資訊面板版面
+- Shift + F: 切換風扇控制與散熱狀態版面
+- F9: 結束選取的行程 (需要 y/n 確認)
+- f: 凍結行程列表
+- /: 搜尋行程列表
+- g/G: 跳至列表頂端/底端
+- + 或 -: 調整更新間隔速度 (快/慢)
+- h 或 ?: 顯示/隱藏此說明選單
+- j/k 或 ↓/↑: 捲動說明文字
+- q 或 <C-c>: 離開應用程式
+
+----啟動參數----
+--help, -h: 顯示此說明選單
+--version, -v: 顯示 mactop 版本
+--interval, -i: 設定更新間隔（毫秒），預設為 1000。
+--prometheus, -p: 設定並啟用 Prometheus 指標連接埠（例如 --prometheus=9090）
+--headless: 以 headless 模式執行 (無 TUI，輸出至 stdout)
+--format: headless 模式輸出格式 (json, yaml, xml, csv, toon)，預設為 json。
+--pretty: 美化 headless 模式輸出
+--count: headless 模式採樣次數 (0 = 無限)
+--dump-ioreport, -d: 傾印所有 IOReport 頻道並結束
+--unit-network: 網路單位設定: auto, byte, kb, mb, gb
+--unit-disk: 磁碟單位設定: auto, byte, kb, mb, gb
+--unit-temp: 溫度單位: celsius(攝氏), fahrenheit(華氏)
+--foreground: 設定 UI 前景色 (名稱或十六進位)
+--bg: 設定 UI 背景色
+--pid: 監控指定的 PID (--pid 1234)
+--fan-control: 啟用互動式風扇控制 (會寫入 SMC 狀態)*
+--menubar: 以 macOS 選單列項目執行 (無 TUI 終端介面)
+
+自訂主題: 建立 ~/.mactop/theme.json 設定檔以自訂顏色
+"""
+
+Info_Auto = "自動"
+Info_Manual = "手動"
+Info_Disconnected = "已中斷 (%s)"
+Info_Enabled = "已啟用"
+Info_Disabled = "已停用"
+Info_ScrollUp = "↑ 向上捲動"
+Info_ScrollDown = "↓ 向下捲動"
+
+
+Menu_Usage = "使用率:"
+Menu_ECluster = "E-叢集:"
+Menu_PCluster = "P-叢集:"
+Menu_SCluster = "S-叢集:"
+Menu_Power = "功耗:"
+Menu_Temp = "溫度:"
+Menu_TFLOPs = "TFLOPs:"
+Menu_RAM = "記憶體:"
+Menu_Swap = "置換:"
+Menu_DRAMBW = "DRAM 頻寬:"
+Menu_Network = "網路:"
+Menu_RDMA = "RDMA:"
+Menu_Disk = "磁碟:"
+Menu_Total = "總計:"
+Menu_System = "系統:"
+Menu_Thermal = "散熱狀態:"
+Menu_Settings = "設定..."
+Menu_OpenGitHub = "開啟 GitHub 資訊..."
+Menu_OpenTUI = "開啟 mactop 終端機..."
+Menu_Quit = "結束 mactop"
+Menu_AppleSilicon = "Apple Silicon"
+Menu_CPU = "CPU"
+Menu_GPU = "GPU"
+Menu_MEMORY = "記憶體"
+Menu_NETWORK = "網路"
+Menu_DISK = "磁碟"
+Menu_POWER = "功耗"
+Menu_HISTORY = "歷史記錄"
+Menu_FANS = "風扇"
+
+CLI_HelpText = """
+用法: mactop [options]
+
+選項:
+  -h, --help              顯示此說明訊息
+  -v, --version           顯示 mactop 版本
+  -i, --interval <ms>     設定更新間隔（毫秒，預設：1000）
+  --foreground <color>    設定 UI 前景色（名稱或十六進位，例如 green, #9580FF）
+  --bg <color>            設定 UI 背景色（名稱或十六進位，例如 mocha-base, #22212C）
+  -p, --prometheus <port> 在指定連接埠啟動 Prometheus 指標伺服器（例如 :9090）
+      --headless          以 headless 模式執行（無 TUI，JSON 輸出至 stdout）
+      --format <format>   設定輸出格式（json, yaml, xml, csv, toon）
+      --pretty            美化 headless 輸出
+      --count <n>         headless 模式採樣次數（0 = 無限）
+      --dump-ioreport, -d 傾印所有可用的 IOReport 頻道並結束
+      --unit-network <unit> 網路單位：auto, byte, kb, mb, gb（預設：auto）
+      --unit-disk <unit>    磁碟單位：auto, byte, kb, mb, gb（預設：auto）
+      --unit-temp <unit>    溫度單位：celsius, fahrenheit（預設：celsius）
+      --pid <pid>         監控指定 PID 的行程
+      --menubar           以 macOS 選單列項目執行（無 TUI）
+      --overlay           於所有應用程式上方顯示浮動 HUD 視窗
+      --overlay-sections  以逗號分隔的可見區塊（例如 cpu,gpu,memory,power）
+      --overlay-opacity   overlay 視窗透明度，0.15-1.0（預設：0.88）
+      --fan-control       啟用互動式風扇控制（會寫入 SMC）
+      --dump-temps        診斷：傾印所有原始 SMC 溫度鍵並結束
+      --dump-debug        診斷：傾印 IOReport/HID/SMC/NVMe 除錯資訊並結束
+
+主題檔案:
+  建立 ~/.mactop/theme.json 以使用自訂十六進位顏色:
+  {"foreground": "#9580FF", "background": "#22212C"}
+
+更多資訊請見 https://github.com/metaspartan/mactop （Carsen Klock）
+"""
+CLI_Version = "mactop 版本: %s"
+CLI_DumpingIOReport = "正在傾印 IOReport 頻道..."
+CLI_TestInputReceived = "已收到測試輸入: %s"
+CLI_ErrorForegroundRequiresValue = "錯誤: --foreground 需要顏色值"
+CLI_ErrorBackgroundRequiresValue = "錯誤: --bg 需要顏色值"
+CLI_ErrorPrometheusRequiresValue = "錯誤: --prometheus 需要連接埠號"
+CLI_ErrorIntervalRequiresValue = "錯誤: --interval 需要間隔值"
+CLI_ErrorInvalidInterval = "無效的間隔值: %v"
+CLI_ErrorPIDRequiresValue = "錯誤: --pid 需要 PID 值"
+CLI_ErrorInvalidPID = "無效的 PID: %v"
+CLI_TestingIOReportPowerMetrics = "正在測試 IOReport 功耗指標..."
+CLI_TestSample = "樣本 %d:"
+CLI_TestSocTemp = "  SoC 溫度: %.1f°C"
+CLI_TestCPU = "  CPU: %.2fW | GPU: %.2fW (%d MHz, %.0f%% active)"
+CLI_TestANE = "  ANE: %.2fW | DRAM: %.2fW | GPU SRAM: %.2fW | 總計: %.2fW | %s"
+
+Headless_ErrorInitMetrics = "初始化指標失敗: %v"
+Headless_ErrorUnknownFormat = "未知格式: %s。將回退至 json。"
+Headless_ErrorFormattingOutput = "格式化輸出時發生錯誤: %v"
+Headless_ErrorPrometheusServer = "Prometheus 伺服器錯誤: %v"
+
+Info_OSValue = "macOS %s"
+Info_TFLOPsValue = "%.1f FP32 / %.1f FP16"
+Info_NotAvailable = "N/A"
+Info_PowerValue = "%.2f W (平均 %.0f W)"
+Info_NetworkValue = "↑ %s/s ↓ %s/s"
+Info_DiskValue = "讀 %s/s 寫 %s/s"
+Info_DRAMBWValue = "讀 %.1f / 寫 %.1f / %.1f GB/s"
+Info_FanValue = "%d RPM (%s, %d-%d)"
+Info_WiFiValue = "%s @ %dMbps (%s)"
+Info_VolumeValue = "%s / %s (%s 可用)"
+
+Fan_CPUTemp = "CPU 溫度"
+Fan_GPUTemp = "GPU 溫度"
+Fan_NoFansDetected = "未偵測到風扇"
+Fan_NoTemperatureSensorsDetected = "未偵測到溫度感測器"
+Fan_ControlActive = "[⚠ 風扇控制啟用中](fg:red,mod:bold)  [+/-](fg:%s,mod:bold) 速度  [a](fg:%s,mod:bold) 自動  [0/9](fg:%s,mod:bold) 最小/最大  [R](fg:green,mod:bold) 重設  [l](fg:%s) 版面  [F](fg:%s) 離開"
+Fan_ReadOnly = "[唯讀](fg:%s)  使用 --fan-control 啟用寫入  |  [l](fg:%s,mod:bold) 版面  [F](fg:%s,mod:bold) 離開風扇檢視"
+
+Metrics_PowerSparklineGroup = "%.2f W 總計 (最大: %.2f W)"
+Metrics_PowerSparklineTitle = "平均: %.2f W | %s"
+Metrics_PowerHistoryDetail = "功耗歷史 (平均: %.1fW, 最大: %.1fW)"
+Metrics_CPUHistoryDetail = "CPU 使用歷史 (%.1f%%)"
+Metrics_MemoryHistoryDetail = "記憶體: %.1f/%.1fGB, 置換: %.1fGB"
+
+TUI_KillPIDTitle = " 確認結束 PID %d "
+
+Menu_Tooltip = "mactop — Apple Silicon 監視器"
+Menu_SettingsTitle = "mactop 選單列設定"
+Menu_ShowCPUBar = "顯示 CPU 條"
+Menu_ShowGPUBar = "顯示 GPU 條"
+Menu_ShowANEBar = "顯示 ANE 條"
+Menu_ShowMemoryBar = "顯示記憶體條"
+Menu_ShowWattageInMenuBar = "在選單列顯示瓦數"
+Menu_ShowPercentages = "顯示百分比"
+Menu_StatusBarWidth = "狀態列寬度:"
+Menu_StatusBarHeight = "狀態列高度:"
+Menu_BarFontSize = "條形字體大小:"
+Menu_WattageFontSize = "功耗字體大小:"
+Menu_Colors = "顏色:"
+Menu_LabelText = "標籤文字"
+Menu_BarOrder = "欄目排列順序："
+Menu_DiskRate = "讀 %.0f KB/s  寫 %.0f KB/s"
+Menu_FanItem = "風扇 %d"
+
+Overlay_DRAM = "DRAM"
+Overlay_CollapsedMode = "折疊模式"
+Overlay_ExpandedMode = "展開模式"
+Overlay_Done = "完成"
+Overlay_RequiresScreenRecordingPermission = "需要螢幕錄製權限"
+Overlay_RequiresPermission = "需要權限"
+Overlay_OpacityHint = "透明度: %.0f%%  (捲動調整)"
+Overlay_GPUCores = "%d 個 GPU 核心"
+Overlay_GPUFreqTFLOPs = "%dMHz • %.1f TFLOPS"
+Overlay_GPUFreqMHz = "%d MHz"
+Overlay_TempsDual = "CPU %.0f°C  GPU %.0f°C"
+Overlay_TempsSingle = "%.0f°C"
+
+# Fan modes & temperature categories
+Fan_Mode_Auto = "自動"
+Fan_Mode_Manual = "手動"
+Fan_TargetRange = "目標: %d RPM  |  範圍: %d – %d RPM"
+Temp_AvgOf = "%d 個平均, %s – %s"
+TempCategory_CPU_ECore = "CPU E 核"
+TempCategory_CPU_PCore = "CPU P 核"
+TempCategory_CPU_SCore = "CPU S 核"
+TempCategory_CPU_ECores = "CPU E 核"
+TempCategory_CPU_PCores = "CPU P 核"
+TempCategory_CPU_SCores = "CPU S 核"
+TempCategory_CPU_Core = "CPU 核心"
+TempCategory_CPU_Die = "CPU Die"
+TempCategory_GPU = "GPU"
+TempCategory_Memory = "記憶體"
+TempCategory_SSD = "SSD"
+TempCategory_NAND = "NAND"
+TempCategory_NVMe = "NVMe"
+TempCategory_Ambient = "環境"
+TempCategory_Board = "主機板"
+TempCategory_VRM = "VRM"
+TempCategory_SocPackage = "SoC 封裝"
+TempCategory_Thunderbolt = "Thunderbolt"
+TempCategory_Wireless = "無線"
+TempCategory_Display = "顯示器"
+TempCategory_Other = "其他"


### PR DESCRIPTION
## Summary
- Adds `active.zh-Hant.toml` — Taiwan-targeted Traditional Chinese translation. Uses localized vocabulary (記憶體, 網路, 行程, 資訊, 選單, 設定, 載入中, 重新整理, etc.) rather than character conversion from the existing Simplified `zh.toml`.
- Routes `zh-TW`, `zh-HK`, `zh-MO`, and `zh-Hant*` tags to `zh-Hant` during system language auto-detection. Without this, Taiwanese/HK/Macao macOS users hit `zh.toml` (Simplified) by default. `zh-Hans` variants continue to resolve to `zh`, so existing Simplified users are unaffected.
- Adds `TestNormalizeLanguageTag` (21 cases covering BCP-47, POSIX, mixed case).
- README bump: 19 → 20 languages.

## Test plan
- [x] `go test ./internal/i18n/...` — all locales pass parity check, new normalize tests pass
- [x] `go test ./internal/app/...` — no regressions
- [x] `./mactop --lang zh-Hant` — Traditional Chinese UI
- [x] `./mactop --lang zh-TW` — go-i18n matcher routes to zh-Hant
- [x] `./mactop --lang zh-CN` — still Simplified
- [x] `LANG=zh_TW.UTF-8 ./mactop` (auto-detect path) — Traditional Chinese

<!-- GITZILLA_SUMMARY -->
> [!NOTE]
> **Low Risk**
>
> **Overview**
> This pull request adds Traditional Chinese (zh-Hant) locale support with a Taiwan-targeted translation file using localized vocabulary such as 記憶體, 網路, and 設定 instead of character-converted Simplified Chinese. The system language auto-detection was updated to route `zh-TW`, `zh-HK`, `zh-MO`, and `zh-Hant*` variants to the new `zh-Hant` locale, ensuring that Taiwanese, Hong Kong, and Macao macOS users receive the correct Traditional Chinese translations rather than Simplified Chinese. Related tests and documentation were updated to support the new locale routing.
>
> <sup>Written by [Gitzilla](https://gitzilla.ai) for commit 0ff7645. This will update automatically on new runs. Configure in the [Gitzilla dashboard](https://gitzilla.ai/dashboard).</sup>
<!-- /GITZILLA_SUMMARY -->