### PR TITLE
refactor: remove obsolete max helper

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -57,27 +57,6 @@ func TestFormatTemp(t *testing.T) {
 	}
 }
 
-func TestMax(t *testing.T) {
-	tests := []struct {
-		name string
-		nums []int
-		want int
-	}{
-		{"Single positive", []int{5}, 5},
-		{"Multiple positive", []int{1, 5, 3}, 5},
-		{"Negative numbers", []int{-1, -5, -3}, -1},
-		{"Mixed numbers", []int{-5, 0, 5}, 5},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := max(tt.nums...); got != tt.want {
-				t.Errorf("max() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestNewCPUMetrics(t *testing.T) {
 	m := NewCPUMetrics()
 	if m.CoreMetrics == nil {

--- a/internal/app/utils.go
+++ b/internal/app/utils.go
@@ -128,16 +128,6 @@ func truncateWithEllipsis(s string, maxLen int) string {
 	return s[:maxLen-3] + "..."
 }
 
-func max(nums ...int) int {
-	maxVal := nums[0]
-	for _, num := range nums[1:] {
-		if num > maxVal {
-			maxVal = num
-		}
-	}
-	return maxVal
-}
-
 func formatBytes(val float64, unitType string) string {
 	units := []string{"B", "KB", "MB", "GB", "TB"}
 


### PR DESCRIPTION
Go 1.21 added max and min as built-in functions, so the local  `max()` helper is no longer necessary.

Remove the custom max implementation and its dedicated TestMax coverage. No call sites need to be changed on the alteration.

<!-- GITZILLA_SUMMARY -->
> [!NOTE]
> **Low Risk**
>
> **Overview**
> This pull request removes a custom `max()` helper function that became obsolete with Go 1.21, which added `max` and `min` as built-in functions. The helper implementation in `internal/app/utils.go` and its corresponding test coverage in `internal/app/app_test.go` have been deleted. No changes to call sites are required since the function's behavior is now provided by the Go standard library.
>
> <sup>Written by [Gitzilla](https://gitzilla.ai) for commit 3e94e29. This will update automatically on new runs. Configure in the [Gitzilla dashboard](https://gitzilla.ai/dashboard).</sup>
<!-- /GITZILLA_SUMMARY -->