### PR TITLE
Add Shift+key reverse cycling for layouts, themes, and backgrounds

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -428,7 +428,7 @@ func togglePartyMode() {
 					partyTicker.Stop()
 					return
 				}
-				cycleTheme()
+				cycleTheme(1)
 				renderMutex.Lock()
 				updateProcessList()
 				width, height := ui.TerminalDimensions()

--- a/internal/app/events.go
+++ b/internal/app/events.go
@@ -122,15 +122,21 @@ func handleModeKeys(key string, done chan struct{}) {
 	case "p":
 		togglePartyMode()
 	case "c":
-		handleThemeCycle()
+		handleThemeCycle(1)
+	case "C":
+		handleThemeCycle(-1)
 	case "l":
-		handleLayoutCycle()
+		handleLayoutCycle(1)
+	case "L":
+		handleLayoutCycle(-1)
 	case "h", "?":
 		toggleHelpMenu()
 	case "i":
 		toggleInfoLayout()
 	case "b":
-		handleBackgroundCycle()
+		handleBackgroundCycle(1)
+	case "B":
+		handleBackgroundCycle(-1)
 	case "f":
 		toggleFreeze()
 	case "F":
@@ -210,7 +216,7 @@ func handleKeyboardEvent(e ui.Event, done chan struct{}) {
 	renderMutex.Unlock()
 
 	switch key {
-	case "q", "<C-c>", "r", "p", "c", "l", "h", "?", "i", "b", "f", "F":
+	case "q", "<C-c>", "r", "p", "c", "C", "l", "L", "h", "?", "i", "b", "B", "f", "F":
 		handleModeKeys(key, done)
 	case "-", "_", "+", "=":
 		if !handleFanControlKeys(key) {

--- a/internal/app/events_helpers.go
+++ b/internal/app/events_helpers.go
@@ -201,11 +201,11 @@ func handleFanResetAuto() {
 	drawScreen(w, h)
 }
 
-func handleThemeCycle() {
+func handleThemeCycle(step int) {
 	renderMutex.Lock()
 	w, h := ui.TerminalDimensions()
 	updateLayout(w, h)
-	cycleTheme()
+	cycleTheme(step)
 	renderMutex.Unlock()
 	renderMutex.Lock()
 	updateProcessList()
@@ -214,9 +214,9 @@ func handleThemeCycle() {
 	renderMutex.Unlock()
 }
 
-func handleLayoutCycle() {
+func handleLayoutCycle(step int) {
 	renderMutex.Lock()
-	cycleLayout()
+	cycleLayout(step)
 	renderMutex.Unlock()
 	saveConfig()
 	renderMutex.Lock()
@@ -225,9 +225,9 @@ func handleLayoutCycle() {
 	renderMutex.Unlock()
 }
 
-func handleBackgroundCycle() {
+func handleBackgroundCycle(step int) {
 	renderMutex.Lock()
-	cycleBackground()
+	cycleBackground(step)
 	w, h := ui.TerminalDimensions()
 	drawScreen(w, h)
 	renderMutex.Unlock()

--- a/internal/app/layout.go
+++ b/internal/app/layout.go
@@ -42,7 +42,7 @@ func setupGrid() {
 	applyLayout(currentConfig.DefaultLayout)
 }
 
-func cycleLayout() {
+func cycleLayout(step int) {
 	currentIndex := 0
 	for i, layout := range layoutOrder {
 		if layout == currentConfig.DefaultLayout {
@@ -50,10 +50,11 @@ func cycleLayout() {
 			break
 		}
 	}
-	nextIndex := (currentIndex + 1) % len(layoutOrder)
+	n := len(layoutOrder)
+	nextIndex := ((currentIndex+step)%n + n) % n
 	currentConfig.DefaultLayout = layoutOrder[nextIndex]
 	currentLayoutNum = nextIndex
-	totalLayouts = len(layoutOrder)
+	totalLayouts = n
 	applyLayout(currentConfig.DefaultLayout)
 	updateHelpText()
 }

--- a/internal/app/theme.go
+++ b/internal/app/theme.go
@@ -555,7 +555,7 @@ func GetProcessTextColor(isCurrentUser bool) string {
 	return "#888888" // Grey for non-current-user (root/system) processes
 }
 
-func cycleTheme() {
+func cycleTheme(step int) {
 	currentIndex := 0
 	for i, name := range themeOrder {
 		if name == currentConfig.Theme {
@@ -563,7 +563,8 @@ func cycleTheme() {
 			break
 		}
 	}
-	nextIndex := (currentIndex + 1) % len(themeOrder)
+	n := len(themeOrder)
+	nextIndex := ((currentIndex+step)%n + n) % n
 	currentColorName = themeOrder[nextIndex]
 
 	// When cycling themes, clear the custom theme configuration to prevent
@@ -600,9 +601,10 @@ func applyInitialBackground() {
 	applyBackground(bgName)
 }
 
-// cycleBackground cycles through background colors
-func cycleBackground() {
-	currentBgIndex = (currentBgIndex + 1) % len(bgColorOrder)
+// cycleBackground cycles through background colors. Positive step advances, negative reverses.
+func cycleBackground(step int) {
+	n := len(bgColorOrder)
+	currentBgIndex = ((currentBgIndex+step)%n + n) % n
 	bgName := bgColorOrder[currentBgIndex]
 	applyBackground(bgName)
 	currentConfig.Background = bgName

--- a/internal/i18n/locales/active.en.toml
+++ b/internal/i18n/locales/active.en.toml
@@ -142,10 +142,10 @@ Update Interval: %dms
 
 ----Controls----
 - r: Refresh the UI data manually
-- c: Cycle through UI color themes
-- b: Cycle through UI background colors
+- c / Shift + C: Cycle UI color themes forward / backward
+- b / Shift + B: Cycle UI background colors forward / backward
 - p: Toggle party mode (color cycling)
-- l: Cycle through the 18 available layouts
+- l / Shift + L: Cycle through the 18 available layouts forward / backward
 - i: Toggle information layout
 - Shift + F: Toggle fan control & thermals layout
 - F9: Kill selected process (y/n confirm)


### PR DESCRIPTION
I added this because it was getting tedious to keep re-cycling to get to the layout I wanted if I clicked L or C by accident.



<!-- GITZILLA_SUMMARY -->
> [!NOTE]
> **Low Risk**
>
> **Overview**
> This pull request adds Shift+key functionality to enable reverse cycling through layouts, themes, and backgrounds. When the Shift modifier is held, pressing the cycle keys (L for layouts, C for themes, etc.) traverses the options in the opposite direction, allowing users to quickly navigate back without cycling through the entire list. The implementation modifies the event handling system to detect Shift key state, and updates the layout and theme cycling logic to respect this modifier for directional control. Localization strings were also adjusted to reflect the new behavior.
>
> <sup>Written by [Gitzilla](https://gitzilla.ai) for commit 7cd3272. This will update automatically on new runs. Configure in the [Gitzilla dashboard](https://gitzilla.ai/dashboard).</sup>
<!-- /GITZILLA_SUMMARY -->