### PR TITLE
Debounce config save to fix +/- keypress lag

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1505,6 +1505,7 @@ func shutdownAndExit(closeDone bool) {
 			}()
 		}
 		shutdownWorkers()
+		saveConfigFlush()
 		ui.Close()
 		os.Exit(0)
 	})

--- a/internal/app/config.go
+++ b/internal/app/config.go
@@ -5,6 +5,18 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
+)
+
+// Coalesce rapid saveConfig calls into one disk write so if you spam +/- (which I do a lot) it doesn't block the event loop on per-press file I/O.
+const saveDebounceInterval = 500 * time.Millisecond
+
+var (
+	saveDebounceMu    sync.Mutex
+	saveDebounceTimer *time.Timer
+	pendingSaveData   []byte
+	pendingSavePath   string
 )
 
 // CustomThemeConfig holds custom hex color values for theming
@@ -266,7 +278,50 @@ func saveConfig() {
 		return
 	}
 
-	os.WriteFile(configPath, data, 0644)
+	// Marshal at schedule time so the value the user just set is the one that lands on disk, even if currentConfig keeps changing before the timer fires.
+	saveDebounceMu.Lock()
+	pendingSaveData = data
+	pendingSavePath = configPath
+	if saveDebounceTimer != nil {
+		saveDebounceTimer.Stop()
+	}
+	saveDebounceTimer = time.AfterFunc(saveDebounceInterval, flushPendingSave)
+	saveDebounceMu.Unlock()
+}
+
+func flushPendingSave() {
+	saveDebounceMu.Lock()
+	data := pendingSaveData
+	path := pendingSavePath
+	pendingSaveData = nil
+	pendingSavePath = ""
+	saveDebounceMu.Unlock()
+
+	if data != nil && path != "" {
+		saveConfigNow(data, path)
+	}
+}
+
+// saveConfigFlush forces any pending debounced save to disk.
+func saveConfigFlush() {
+	saveDebounceMu.Lock()
+	if saveDebounceTimer != nil {
+		saveDebounceTimer.Stop()
+		saveDebounceTimer = nil
+	}
+	data := pendingSaveData
+	path := pendingSavePath
+	pendingSaveData = nil
+	pendingSavePath = ""
+	saveDebounceMu.Unlock()
+
+	if data != nil && path != "" {
+		saveConfigNow(data, path)
+	}
+}
+
+func saveConfigNow(data []byte, path string) {
+	os.WriteFile(path, data, 0644)
 }
 
 // loadThemeFile loads custom theme from ~/.mactop/theme.json if it exists


### PR DESCRIPTION
Hey!  
  
So, this and the last PR are one of my first few PRs ever, so apologies in advance if I missed anything obvious, I’ll be happy to revise!!!

I noticed that pressing `+` or `-` to change the update interval felt laggy when I spammed it, and `l`/`c`/`b` had the same problem. So, I tracked it down to `saveConfig()` doing a synchronous JSON marshal + `os.WriteFile` on every call, so each keypress was blocked behind a disk write.


<!-- GITZILLA_SUMMARY -->
> [!NOTE]
> **Low Risk**
>
> **Overview**
> This pull request fixes input lag when pressing `+`, `-`, `l`, `c`, or `b` keys to change configuration settings. The issue was caused by `saveConfig()` performing a synchronous JSON marshal and file write on every keypress, blocking user input behind disk I/O. The fix introduces debouncing to batch multiple rapid config saves into a single write operation. Changes are made to `internal/app/config.go` (core debouncing logic) and `internal/app/app.go` (wiring up the debounced save).
>
> <sup>Written by [Gitzilla](https://gitzilla.ai) for commit b0f1083. This will update automatically on new runs. Configure in the [Gitzilla dashboard](https://gitzilla.ai/dashboard).</sup>
<!-- /GITZILLA_SUMMARY -->